### PR TITLE
[TR-1699] Magento - API Debug route

### DIFF
--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Tapbuy Redirect and Tracking Logger Handler
  *
@@ -9,17 +10,69 @@
 namespace Tapbuy\RedirectTracking\Logger;
 
 use Magento\Framework\Logger\Handler\Base;
+use Magento\Framework\Filesystem\DriverInterface;
+use Magento\Framework\HTTP\Client\Curl;
 use Monolog\Logger;
+use Tapbuy\RedirectTracking\Model\Config;
 
 class Handler extends Base
 {
     /**
      * @var int
+     * Handle all levels from DEBUG upward so debug() is sent.
+     * (Change back to Logger::INFO if you only want >= INFO.)
      */
-    protected $loggerType = Logger::INFO;
+    protected $loggerType = Logger::DEBUG;
 
     /**
      * @var string
      */
     protected $fileName = '/var/log/tapbuy.log';
+
+    /** @var Curl */
+    private $curl;
+
+    /** @var Config */
+    private $config;
+
+    /** @var string */
+    private $baseUrl;
+
+    public function __construct(
+        DriverInterface $filesystem,
+        Curl $curl,
+        Config $config,
+        $filePath = null
+    ) {
+        $this->curl = $curl;
+        $this->config = $config;
+        // Remove trailing slash to avoid double slashes when appending /debug
+        $this->baseUrl = rtrim((string)$this->config->getApiUrl(), '/');
+        parent::__construct($filesystem, $filePath);
+    }
+
+    /**
+     * Write record to file and POST to /debug
+     * @param array $record
+     */
+    protected function write(array $record): void
+    {
+        parent::write($record);
+
+        $payload = [
+            'message' => (string)$record['message'],
+            'level' => (int)$record['level'],
+            'level_name' => (string)$record['level_name'],
+            'params' => isset($record['context']['params']) ? (array)$record['context']['params'] : (array)$record['context'],
+            'sentry' => $record['context']['sentry'] ?? false
+        ];
+
+        try {
+            $this->curl->addHeader('Content-Type', 'application/json');
+            $this->curl->addHeader('Authorization', 'Bearer ' . $this->config->getEncryptionKey());
+            $this->curl->post($this->baseUrl . '/debug', json_encode($payload));
+        } catch (\Throwable $e) {
+            // Silently ignore to not block logging
+        }
+    }
 }

--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -64,7 +64,7 @@ class Handler extends Base
             'level' => (int)$record['level'],
             'level_name' => (string)$record['level_name'],
             'params' => isset($record['context']['params']) ? (array)$record['context']['params'] : (array)$record['context'],
-            'sentry' => $record['context']['sentry'] ?? false
+            'sentry' => ($record['context'] ?? [])['sentry'] ?? false
         ];
 
         try {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -5,17 +5,11 @@
     <preference for="Tapbuy\RedirectTracking\Api\TapbuyServiceInterface" type="Tapbuy\RedirectTracking\Model\Service" />
     
     <!-- Virtual Types -->
-    <virtualType name="Tapbuy\RedirectTracking\Logger\Handler" type="Magento\Framework\Logger\Handler\Base">
-        <arguments>
-            <argument name="fileName" xsi:type="string">/var/log/tapbuy.log</argument>
-        </arguments>
-    </virtualType>
-    
     <virtualType name="Tapbuy\RedirectTracking\Logger\Logger" type="Magento\Framework\Logger\Monolog">
         <arguments>
             <argument name="name" xsi:type="string">tapbuy</argument>
             <argument name="handlers" xsi:type="array">
-                <item name="system" xsi:type="object">Tapbuy\RedirectTracking\Logger\Handler</item>
+                <item name="tapbuy_handler" xsi:type="object">Tapbuy\RedirectTracking\Logger\Handler</item>
             </argument>
         </arguments>
     </virtualType>
@@ -27,7 +21,10 @@
         </arguments>
     </type>
 
-    <!-- Resolvers -->
-    <type name="Tapbuy\RedirectTracking\Model\Resolver\Redirect">
+    <!-- Inject custom logger into the Helper -->
+    <type name="Tapbuy\RedirectTracking\Helper\Data">
+        <arguments>
+            <argument name="logger" xsi:type="object">Tapbuy\RedirectTracking\Logger\Logger</argument>
+        </arguments>
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <!-- di.xml -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">    
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+
     <!-- Preferences -->
-    <preference for="Tapbuy\RedirectTracking\Api\TapbuyServiceInterface" type="Tapbuy\RedirectTracking\Model\Service" />
-    
-    <!-- Virtual Types -->
+    <preference for="Tapbuy\RedirectTracking\Api\TapbuyServiceInterface"
+                type="Tapbuy\RedirectTracking\Model\Service"/>
+
+    <!-- Custom Monolog instance with our Handler -->
     <virtualType name="Tapbuy\RedirectTracking\Logger\Logger" type="Magento\Framework\Logger\Monolog">
         <arguments>
             <argument name="name" xsi:type="string">tapbuy</argument>
@@ -13,16 +16,27 @@
             </argument>
         </arguments>
     </virtualType>
-    
-    <!-- Service Interface -->
+
+    <!-- Inject logger where LoggerInterface is type‑hinted -->
     <type name="Tapbuy\RedirectTracking\Model\Service">
         <arguments>
             <argument name="logger" xsi:type="object">Tapbuy\RedirectTracking\Logger\Logger</argument>
         </arguments>
     </type>
 
-    <!-- Inject custom logger into the Helper -->
     <type name="Tapbuy\RedirectTracking\Helper\Data">
+        <arguments>
+            <argument name="logger" xsi:type="object">Tapbuy\RedirectTracking\Logger\Logger</argument>
+        </arguments>
+    </type>
+
+    <type name="Tapbuy\RedirectTracking\Model\ABTest">
+        <arguments>
+            <argument name="logger" xsi:type="object">Tapbuy\RedirectTracking\Logger\Logger</argument>
+        </arguments>
+    </type>
+
+    <type name="Tapbuy\RedirectTracking\Observer\OrderSaveAfter">
         <arguments>
             <argument name="logger" xsi:type="object">Tapbuy\RedirectTracking\Logger\Logger</argument>
         </arguments>


### PR DESCRIPTION
This pull request enhances the logging system for the Tapbuy Redirect and Tracking module by upgrading the custom logger to handle debug-level logs and send log entries to a remote `/debug` endpoint. It also updates dependency injection to ensure the new logger is used throughout the module.

**Logger enhancements:**

* Changed the log level in `Handler.php` to handle all logs from DEBUG upwards, ensuring more granular logging is captured.
* Modified the `write` method in `Handler.php` to POST log records to a remote `/debug` endpoint, including relevant log details and authentication.
* Added dependencies for HTTP client (`Curl`) and configuration (`Config`) to the logger handler to support remote logging.

**Dependency injection and configuration:**

* Removed the previous virtual type for the logger handler and updated the logger handler reference in `di.xml` to use the custom `Tapbuy\RedirectTracking\Logger\Handler`.
* Injected the custom logger into the `Tapbuy\RedirectTracking\Helper\Data` class to ensure all helper logging uses the enhanced logger.