### PR TITLE
[MSK-32] Locale Format

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -154,7 +154,17 @@ class Data extends AbstractHelper
      */
     public function getLocale()
     {
-        return $this->localeResolver->getLocale();
+        $locale = $this->localeResolver->getLocale();
+        if ($this->config->getLocaleFormat() === 'short') {
+            if (strpos($locale, '_') !== false) {
+                return substr($locale, 0, strpos($locale, '_'));
+            }
+            if (strpos($locale, '-') !== false) {
+                return substr($locale, 0, strpos($locale, '-'));
+            }
+            return substr($locale, 0, 2);
+        }
+        return $locale;
     }
 
     /**

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -21,6 +21,7 @@ class Config
     public const XML_PATH_API_URL = 'tapbuy/api/api_url';
     public const XML_PATH_API_KEY = 'tapbuy/api/api_key';
     public const XML_PATH_ENCRYPTION_KEY = 'tapbuy/api/encryption_key';
+    public const XML_PATH_LOCALE_FORMAT = 'tapbuy/api/locale_format';
     public const XML_PATH_GIFTING_ENABLED = 'tapbuy/gifting/enabled';
     public const XML_PATH_GIFTING_URL = 'tapbuy/gifting/gifting_url';
 
@@ -180,5 +181,20 @@ class Config
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
+    }
+
+    /**
+     * Get Locale Format (long|short)
+     *
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getLocaleFormat($storeId = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_LOCALE_FORMAT,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ) ?: 'long';
     }
 }

--- a/Model/Config/Source/LocaleFormat.php
+++ b/Model/Config/Source/LocaleFormat.php
@@ -1,0 +1,20 @@
+<?php
+namespace Tapbuy\RedirectTracking\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class LocaleFormat implements OptionSourceInterface
+{
+    /**
+     * Return array of options as value-label pairs
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 'long', 'label' => __('Long')],
+            ['value' => 'short', 'label' => __('Short')],
+        ];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -51,6 +51,14 @@
                         <field id="tapbuy/general/enabled">1</field>
                     </depends>
                 </field>
+                <field id="locale_format" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Locale format</label>
+                    <comment>Long: en_US, Short: en</comment>
+                    <source_model>Tapbuy\RedirectTracking\Model\Config\Source\LocaleFormat</source_model>
+                    <depends>
+                        <field id="tapbuy/general/enabled">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="gifting" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Gifting Settings</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <tapbuy>
+            <api>
+                <locale_format>long</locale_format>
+            </api>
+        </tapbuy>
+    </default>
+</config>


### PR DESCRIPTION
This pull request introduces support for configurable locale formats, allowing users to choose between "long" (e.g., `en_US`) and "short" (e.g., `en`) representations. The changes add a new configuration option in the admin panel, update backend logic to respect this setting, and ensure a default value is provided.

**Locale format configuration:**

* Added a new `locale_format` field to the admin configuration (`etc/adminhtml/system.xml`), allowing selection between "Long" and "Short" formats, with options provided by the new `LocaleFormat` source model. [[1]](diffhunk://#diff-89223417b0d8b4f3be81bd4caf5573ad94c01df7d6e897cb48352e7c6204af25R54-R61) [[2]](diffhunk://#diff-d619e6ff6b997e6d82ea3187238ea7824f5d9cb679385ad285d40be0ba3e444bR1-R20)
* Introduced a default value for `locale_format` ("long") in `etc/config.xml` to ensure consistent behavior when the setting is not specified.

**Backend logic updates:**

* Defined the constant `XML_PATH_LOCALE_FORMAT` in `Model/Config.php` and implemented the `getLocaleFormat()` method to retrieve the configuration value, defaulting to "long" if unset. [[1]](diffhunk://#diff-9d8f8bb39dfd46426a24d8fd10c888e246a3a501d2684a7a3af5da46b8c8af58R24) [[2]](diffhunk://#diff-9d8f8bb39dfd46426a24d8fd10c888e246a3a501d2684a7a3af5da46b8c8af58R185-R199)
* Updated the `getLocale()` method in `Helper/Data.php` to return the locale in either "long" or "short" format based on the configuration setting.