### PR TITLE
[MSK-32] Locale format

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -154,7 +154,17 @@ class Data extends AbstractHelper
      */
     public function getLocale()
     {
-        return $this->localeResolver->getLocale();
+        $locale = $this->localeResolver->getLocale();
+        if ($this->config->getLocaleFormat() === 'short') {
+            if (strpos($locale, '_') !== false) {
+                return substr($locale, 0, strpos($locale, '_'));
+            }
+            if (strpos($locale, '-') !== false) {
+                return substr($locale, 0, strpos($locale, '-'));
+            }
+            return substr($locale, 0, 2);
+        }
+        return $locale;
     }
 
     /**

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -21,6 +21,7 @@ class Config
     public const XML_PATH_API_URL = 'tapbuy/api/api_url';
     public const XML_PATH_API_KEY = 'tapbuy/api/api_key';
     public const XML_PATH_ENCRYPTION_KEY = 'tapbuy/api/encryption_key';
+    public const XML_PATH_LOCALE_FORMAT = 'tapbuy/api/locale_format';
     public const XML_PATH_GIFTING_ENABLED = 'tapbuy/gifting/enabled';
     public const XML_PATH_GIFTING_URL = 'tapbuy/gifting/gifting_url';
 
@@ -180,5 +181,20 @@ class Config
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
+    }
+
+    /**
+     * Get Locale Format (long|short)
+     *
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getLocaleFormat($storeId = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_LOCALE_FORMAT,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        ) ?: 'long';
     }
 }

--- a/Model/Config/Source/LocaleFormat.php
+++ b/Model/Config/Source/LocaleFormat.php
@@ -1,0 +1,20 @@
+<?php
+namespace Tapbuy\RedirectTracking\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class LocaleFormat implements OptionSourceInterface
+{
+    /**
+     * Return array of options as value-label pairs
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 'long', 'label' => __('Long')],
+            ['value' => 'short', 'label' => __('Short')],
+        ];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -51,6 +51,14 @@
                         <field id="tapbuy/general/enabled">1</field>
                     </depends>
                 </field>
+                <field id="locale_format" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Locale format</label>
+                    <comment>Long: en_US, Short: en</comment>
+                    <source_model>Tapbuy\RedirectTracking\Model\Config\Source\LocaleFormat</source_model>
+                    <depends>
+                        <field id="tapbuy/general/enabled">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="gifting" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Gifting Settings</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <tapbuy>
+            <api>
+                <locale_format>long</locale_format>
+            </api>
+        </tapbuy>
+    </default>
+</config>


### PR DESCRIPTION
This pull request adds support for configurable locale formats in the Tapbuy module, allowing users to select between "long" (e.g., `en_US`) and "short" (e.g., `en`) locale representations. The most important changes include introducing a new configuration option for locale format, updating the code to handle both formats, and providing the necessary backend and admin panel support.

**Locale Format Configuration:**

* Added a new config option `locale_format` with default value `long` in `etc/config.xml` and exposed it in the admin panel via `etc/adminhtml/system.xml`, allowing users to choose between "Long" (`en_US`) and "Short" (`en`) formats. [[1]](diffhunk://#diff-3bf05ed19b66e6338063bab879891ccbe11ba078352dec2a9ec57ec37bff15bbR1-R10) [[2]](diffhunk://#diff-89223417b0d8b4f3be81bd4caf5573ad94c01df7d6e897cb48352e7c6204af25R54-R61)

* Implemented the `Tapbuy\RedirectTracking\Model\Config\Source\LocaleFormat` class to provide selectable options for locale format in the admin configuration.

**Backend Support for Locale Format:**

* Added `XML_PATH_LOCALE_FORMAT` constant and `getLocaleFormat()` method to `Model/Config.php` to retrieve the configured locale format, defaulting to "long" if not set. [[1]](diffhunk://#diff-9d8f8bb39dfd46426a24d8fd10c888e246a3a501d2684a7a3af5da46b8c8af58R24) [[2]](diffhunk://#diff-9d8f8bb39dfd46426a24d8fd10c888e246a3a501d2684a7a3af5da46b8c8af58R185-R199)

* Updated `Helper/Data.php` to return the locale in either "long" or "short" format based on the configuration, parsing the locale string accordingly.