### PR TITLE
[MSK-125] Redirect referer

### DIFF
--- a/Model/Resolver/Redirect.php
+++ b/Model/Resolver/Redirect.php
@@ -106,6 +106,7 @@ class Redirect implements ResolverInterface
         $this->helper->setCookies($cookies);
 
         $forceRedirect = isset($input['force_redirect']) ? $input['force_redirect'] : null;
+        $referer = isset($input['referer']) ? $input['referer'] : null;
 
         if (!is_numeric($cartId)) {
             $maskedId = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
@@ -138,7 +139,7 @@ class Redirect implements ResolverInterface
             ];
         }
 
-        $result = $this->service->triggerABTest($quote, $forceRedirect);
+        $result = $this->service->triggerABTest($quote, $forceRedirect, $referer);
 
         // Generate pixel URL for headless frontend
         $pixelData = $this->helper->generatePixelData($args['input']['cart_id'], $result, 'redirect_check');

--- a/Model/Service.php
+++ b/Model/Service.php
@@ -177,7 +177,7 @@ class Service
      *
      * @return array|bool
      */
-    public function triggerABTest($quote, $forceRedirect = null)
+    public function triggerABTest($quote, $forceRedirect = null, $referer = null)
     {
         if (!$this->config->isEnabled() || $this->helper->isTapbuyApiRequest()) {
             return ['redirect' => false];
@@ -197,6 +197,7 @@ class Service
                 'cookies' => $this->helper->getStoreCookies(),
                 'key' => $this->helper->getTapbuyKey($quote),
                 'locale' => $this->helper->getLocale(),
+                'referer' => $referer,
                 'forceRedirect' => $forceRedirect,
             ];
 

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -9,6 +9,7 @@ input TapbuyRedirectInput {
     cart_id: String!
     force_redirect: String
     cookies: String
+    referer: String
 }
 
 input TapbuyConfirmOrderInput {


### PR DESCRIPTION
This pull request updates the redirect flow to include the `referer` field throughout the backend and GraphQL schema. The main changes ensure that the `referer` value from the frontend is passed through the resolver and service layers, and is included in the payload for A/B test triggering.

**GraphQL and Input Handling:**

* Added a new `referer` field to the `TapbuyRedirectInput` type in the GraphQL schema to allow the frontend to pass the referer value.
* Updated the resolver in `Redirect.php` to extract the `referer` field from input and pass it to the service layer.

**Backend Service Integration:**

* Modified the `triggerABTest` method signature in `Service.php` to accept the new `referer` parameter.
* Included the `referer` value in the payload sent to the A/B test logic within `triggerABTest`.
* Updated the call to `triggerABTest` in `Redirect.php` to pass the `referer` argument.