### PR TITLE
[INFRA-261] Create organisation to publish NPM package

### DIFF
--- a/HEADLESS_INTEGRATION.md
+++ b/HEADLESS_INTEGRATION.md
@@ -73,7 +73,7 @@ const response = await graphql(TAPBUY_REDIRECT_QUERY, {
 
 ### 3. Frontend fires pixel using the NPM module (with cookies)
 ```javascript
-import { TapbuyPixelTracker } from '@tapbuy/pixel-tracker';
+import { TapbuyPixelTracker } from '@tapbuy-group/pixel-tracker';
 
 const tracker = new TapbuyPixelTracker({
   cookies: { keys: ['tb-abtest-id', '_ga', '_pcid'] } // or 'all' for all cookies


### PR DESCRIPTION
This pull request updates the import path for the `TapbuyPixelTracker` in the documentation to reflect the new package namespace.

- Documentation update:
  * Changed the import statement in `HEADLESS_INTEGRATION.md` to use `@tapbuy-group/pixel-tracker` instead of `@tapbuy/pixel-tracker`.