### PR TITLE
[TR-1786] Pixel url without store

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -18,6 +18,7 @@ use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\HTTP\Header;
 use Magento\Framework\Locale\Resolver;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\UrlInterface;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Tapbuy\RedirectTracking\Model\Config;
@@ -424,7 +425,7 @@ class Data extends AbstractHelper
      */
     public function generatePixelUrl(array $data = []): string
     {
-        $baseUrl = $this->storeManager->getStore()->getBaseUrl();
+        $baseUrl = $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_WEB);
         $encodedData = base64_encode(json_encode($data));
 
         return $baseUrl . 'tapbuy/pixel/track?data=' . $encodedData;


### PR DESCRIPTION
This pull request makes a minor update to the way pixel tracking URLs are generated in the `Helper/Data.php` file by specifying the URL type for the store base URL. This change ensures that the correct web URL is used when building pixel tracking links.

* Updated the call to `getBaseUrl()` in `generatePixelUrl` to explicitly use `UrlInterface::URL_TYPE_WEB`, ensuring pixel tracking URLs use the correct web base URL.
* Added `Magento\Framework\UrlInterface` to the import statements to support the new URL type usage.