### PR TITLE
PDT-489 Replace generic exceptions

### DIFF
--- a/Controller/Pixel/Track.php
+++ b/Controller/Pixel/Track.php
@@ -128,7 +128,7 @@ class Track implements HttpGetActionInterface
             if ($pixelData && is_array($pixelData)) {
                 $this->processPixelData($pixelData);
             }
-        } catch (\Exception $e) {
+        } catch (\RuntimeException $e) {
             $this->logger->logException('Pixel tracking error', $e, [
                 'data' => $this->request->getParam('data'),
             ]);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -254,7 +254,7 @@ class Data extends AbstractHelper implements DataHelperInterface
     {
         try {
             return $this->appState->getMode() === State::MODE_DEVELOPER;
-        } catch (\Exception $e) {
+        } catch (\RuntimeException $e) {
             // If we can't determine mode, assume production for security
             return false;
         }

--- a/Logger/TraceIdProcessor.php
+++ b/Logger/TraceIdProcessor.php
@@ -86,8 +86,8 @@ class TraceIdProcessor implements ProcessorInterface
         try {
             $traceId = $this->tapbuyRequestDetector->getTraceId();
             return $traceId !== null ? $traceId : false;
-        } catch (\Exception $e) {
-            // Fail silently to avoid breaking logging
+        } catch (\Throwable $e) {
+            // Fail silently — must never break the logging pipeline
             return false;
         }
     }

--- a/Model/ABTest.php
+++ b/Model/ABTest.php
@@ -106,7 +106,8 @@ class ABTest implements ABTestInterface
             }
 
             $this->helper->updateABTestCookie($result ? ($result['id'] ?? null) : null);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // Tapbuy tracking only — must never disrupt the order flow
             $this->logger->logException('Error processing order transaction', $e, [
                 'order_id' => $order->getIncrementId(),
             ]);

--- a/Model/Authorization/TokenAuthorization.php
+++ b/Model/Authorization/TokenAuthorization.php
@@ -236,7 +236,8 @@ class TokenAuthorization implements TokenAuthorizationInterface
             $userId = $this->userContext->getUserId();
 
             return $userId > 0 && in_array($userType, self::ACCEPTED_USER_TYPES);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // Any error (including \TypeError from misconfigured framework calls) should deny access
             return false;
         }
     }

--- a/Model/Resolver/ConfirmOrder.php
+++ b/Model/Resolver/ConfirmOrder.php
@@ -9,6 +9,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\OrderPaymentRepositoryInterface;
 use Tapbuy\RedirectTracking\Api\ABTestInterface;
@@ -137,7 +138,13 @@ class ConfirmOrder implements ResolverInterface
             }
 
             return true;
-        } catch (\Exception $e) {
+        } catch (CouldNotSaveException $e) {
+            $this->logger->logException('ConfirmOrder: Failed to save payment tracking flag', $e, [
+                'order_number' => $orderNumber,
+                'ab_test_id' => $abTestId,
+            ]);
+            return true;
+        } catch (\RuntimeException $e) {
             $this->logger->logException('ConfirmOrder: Error processing order confirmation', $e, [
                 'order_number' => $orderNumber,
                 'ab_test_id' => $abTestId,

--- a/Model/Service.php
+++ b/Model/Service.php
@@ -140,7 +140,10 @@ class Service implements TapbuyServiceInterface
             );
 
             return false;
-        } catch (\Exception $e) {
+        } catch (\InvalidArgumentException | \RuntimeException | \Exception $e) {
+            // \InvalidArgumentException: Json::unserialize() on a malformed API response
+            // \RuntimeException: general transport failures
+            // \Exception: Magento Curl client may throw bare \Exception — kept here as last resort
             $this->logger->logException('Error sending Tapbuy API request', $e, [
                 'endpoint' => $endpoint,
             ]);
@@ -175,7 +178,7 @@ class Service implements TapbuyServiceInterface
             ];
 
             return $this->sendRequest('/ab-test/transaction', $payload);
-        } catch (\Exception $e) {
+        } catch (\RuntimeException $e) {
             $this->logger->logException('Error sending transaction to Tapbuy', $e, [
                 'order_id' => $order->getIncrementId(),
             ]);
@@ -224,7 +227,7 @@ class Service implements TapbuyServiceInterface
 
             $this->helper->updateABTestCookie(null);
             return ['redirect' => false];
-        } catch (\Exception $e) {
+        } catch (\RuntimeException $e) {
             $this->logger->logException('Error triggering A/B test', $e);
             $this->helper->updateABTestCookie(null);
             return ['redirect' => false];

--- a/Model/Service.php
+++ b/Model/Service.php
@@ -140,11 +140,23 @@ class Service implements TapbuyServiceInterface
             );
 
             return false;
-        } catch (\InvalidArgumentException | \RuntimeException | \Exception $e) {
-            // \InvalidArgumentException: Json::unserialize() on a malformed API response
-            // \RuntimeException: general transport failures
-            // \Exception: Magento Curl client may throw bare \Exception — kept here as last resort
+        } catch (\InvalidArgumentException $e) {
+            // Json::unserialize() on a malformed API response
+            $this->logger->logException('Error parsing Tapbuy API response', $e, [
+                'endpoint' => $endpoint,
+            ]);
+
+            return false;
+        } catch (\RuntimeException $e) {
+            // General transport failures
             $this->logger->logException('Error sending Tapbuy API request', $e, [
+                'endpoint' => $endpoint,
+            ]);
+
+            return false;
+        } catch (\Exception $e) {
+            // Magento Curl client may throw bare \Exception — kept as last resort
+            $this->logger->logException('Unexpected error sending Tapbuy API request', $e, [
                 'endpoint' => $endpoint,
             ]);
 

--- a/Observer/OrderSaveAfter.php
+++ b/Observer/OrderSaveAfter.php
@@ -111,7 +111,8 @@ class OrderSaveAfter implements ObserverInterface
             self::$processedOrderIds[$orderId] = true;
 
             $this->abTest->processOrderTransaction($order);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // Tapbuy tracking only — must never disrupt the order flow
             $this->logger->logException('Error in Tapbuy order save processing', $e);
         }
     }


### PR DESCRIPTION
This pull request focuses on improving exception handling throughout the codebase. The main changes involve replacing broad `\Exception` catches with more specific exception types, ensuring that errors are handled appropriately for each context. This results in more reliable error handling, prevents unintended side effects, and clarifies the intent behind each catch block.

**Exception Handling Improvements**

* Replaced `\Exception` with more specific exception types such as `\RuntimeException`, `\Throwable`, and custom exceptions in multiple methods, including `execute` in `Controller/Pixel/Track.php`, `isDevelopmentMode` in `Helper/Data.php`, and several methods in `Model/Service.php`. This ensures errors are handled according to their nature and context. [[1]](diffhunk://#diff-e195bb30329f3d1d9d87a121183a5c37d0f656d2f50f8cc700c7323dde3361c7L131-R131) [[2]](diffhunk://#diff-d52e7365b52ebb360796c9734ab3a62d2bd9f6097e38c253892c3d22a36668b5L257-R257) [[3]](diffhunk://#diff-315cfdb5c298e431610d30e3315202a963ca51fe5b5d8345fd03520e1e09c6ddL143-R146) [[4]](diffhunk://#diff-315cfdb5c298e431610d30e3315202a963ca51fe5b5d8345fd03520e1e09c6ddL178-R181) [[5]](diffhunk://#diff-315cfdb5c298e431610d30e3315202a963ca51fe5b5d8345fd03520e1e09c6ddL227-R230)

* Updated catch blocks in business logic methods (`processOrderTransaction` in `Model/ABTest.php`, `execute` in `Observer/OrderSaveAfter.php`, `isAuthorized` in `Model/Authorization/TokenAuthorization.php`, and `extractTraceId` in `Logger/TraceIdProcessor.php`) to use `\Throwable`, ensuring that all errors—including non-Exception throwables—are caught and handled gracefully. This prevents disruptions in critical flows such as order processing and authorization. [[1]](diffhunk://#diff-f29e7ddf2d4b635997b6a1ba1dd3f53add7a55f769922c6a4aebce5a94c9aec0L109-R110) [[2]](diffhunk://#diff-5e8b2493752e9ea31314437d48807a97ef641af23e0637235efe086251a87e1eL114-R115) [[3]](diffhunk://#diff-8c1e225ec8192fdcce9aa8b1dec871bcc640f4aeee0c4b01eba9c13ef188e20dL239-R240) [[4]](diffhunk://#diff-aa0846110d44d39ca7bdbf49d7f7fb7caf601702c1f1749f82bf0baefb0d7b0dL89-R90)

**GraphQL Resolver Specificity**

* In `Model/Resolver/ConfirmOrder.php`, added explicit handling for `CouldNotSaveException` and `\RuntimeException` in the `resolve` method. This provides more granular logging and prevents failures from propagating to the user when saving payment tracking flags fails. [[1]](diffhunk://#diff-c13d46efb6092452164a2bac9d18cab5e8520b6be370eeb01ceeb63c37e6a318L140-R147) [[2]](diffhunk://#diff-c13d46efb6092452164a2bac9d18cab5e8520b6be370eeb01ceeb63c37e6a318R12)

These changes collectively make the codebase more robust and maintainable by ensuring exception handling is context-aware and does not inadvertently disrupt key application flows.