### PR TITLE
PDT-480 Missing docblocks

### DIFF
--- a/Service/CookieService.php
+++ b/Service/CookieService.php
@@ -170,9 +170,13 @@ class CookieService
     }
 
     /**
-     * Get tracking cookies for Tapbuy
+     * Get tracking cookies for Tapbuy.
      *
-     * @return array
+     * Collects analytics cookies (e.g. _ga, _pcid and their prefixed variants)
+     * from the CookieReader, injected cookies, and the raw HTTP request.
+     * Request cookies take precedence over injected ones when the same name appears in both.
+     *
+     * @return array<string, string> Cookie name => value map.
      */
     public function getTrackingCookies(): array
     {
@@ -203,9 +207,12 @@ class CookieService
     }
 
     /**
-     * Get store cookies for Tapbuy
+     * Get store cookies for Tapbuy.
      *
-     * @return array
+     * Collects Magento store-state cookies whose names start with 'mage-cache-' or
+     * 'mage-messages'. Injected cookies override browser cookies for the same name.
+     *
+     * @return array<string, string> Cookie name => value map.
      */
     public function getStoreCookies(): array
     {

--- a/Service/CookieService.php
+++ b/Service/CookieService.php
@@ -174,9 +174,13 @@ class CookieService
      *
      * Collects analytics cookies (e.g. _ga, _pcid and their prefixed variants)
      * from the CookieReader, injected cookies, and the raw HTTP request.
-     * Request cookies take precedence over injected ones when the same name appears in both.
+     * Exact-name cookies retrieved from the CookieReader take precedence and are not
+     * overwritten by other sources. For prefix-matched cookies, request cookies take
+     * precedence over injected ones when the same name appears in both.
+     * Overall precedence: CookieReader exact matches > request prefix matches
+     * > injected prefix matches.
      *
-     * @return array<string, string> Cookie name => value map.
+     * @return array<string, mixed> Cookie name => value map.
      */
     public function getTrackingCookies(): array
     {

--- a/Service/EncryptionService.php
+++ b/Service/EncryptionService.php
@@ -63,10 +63,11 @@ class EncryptionService
      *
      * Serializes session and cart data to JSON, then encrypts it with AES-256-GCM
      * using the configured encryption key. Returns an empty string when the key
-     * is not configured or encryption fails.
+     * is not configured.
      *
      * @param \Magento\Quote\Api\Data\CartInterface|null $quote Active quote, or null when unavailable.
-     * @return string Base64-encoded encrypted payload, or empty string on failure.
+     * @return string Base64-encoded encrypted payload, or empty string when no encryption key is configured.
+     * @throws \Exception If encryption fails.
      */
     public function getTapbuyKey($quote): string
     {

--- a/Service/EncryptionService.php
+++ b/Service/EncryptionService.php
@@ -59,10 +59,14 @@ class EncryptionService
     }
 
     /**
-     * Get encrypted key for Tapbuy
+     * Get encrypted key for Tapbuy.
      *
-     * @param \Magento\Quote\Api\Data\CartInterface|null $quote
-     * @return string
+     * Serializes session and cart data to JSON, then encrypts it with AES-256-GCM
+     * using the configured encryption key. Returns an empty string when the key
+     * is not configured or encryption fails.
+     *
+     * @param \Magento\Quote\Api\Data\CartInterface|null $quote Active quote, or null when unavailable.
+     * @return string Base64-encoded encrypted payload, or empty string on failure.
      */
     public function getTapbuyKey($quote): string
     {
@@ -80,10 +84,16 @@ class EncryptionService
     }
 
     /**
-     * Build encryption data from request and quote
+     * Build encryption data from request and quote.
      *
-     * @param \Magento\Quote\Api\Data\CartInterface|null $quote
-     * @return array
+     * Extracts the Bearer token from the Authorization header and the masked cart ID
+     * from the quote. Only the keys that are available at call-time are included.
+     *
+     * @param \Magento\Quote\Api\Data\CartInterface|null $quote Active quote, or null when unavailable.
+     * @return array{
+     *   session_id?: string,
+     *   cart_id?: string
+     * }
      */
     private function buildEncryptionData($quote): array
     {

--- a/Service/PixelService.php
+++ b/Service/PixelService.php
@@ -47,12 +47,19 @@ class PixelService
     }
 
     /**
-     * Generate pixel data for A/B test tracking
+     * Generate pixel data for A/B test tracking.
      *
-     * @param string $cartId
-     * @param array $testResult
-     * @param string $action
-     * @return array
+     * @param string $cartId Masked or numeric cart identifier.
+     * @param array $testResult A/B test result data; expects optional 'id' key.
+     * @param string $action Tracking action label (e.g. 'redirect_check').
+     * @return array{
+     *   cart_id: string,
+     *   test_id: string|null,
+     *   action: string,
+     *   timestamp: int,
+     *   variation_id: string|null,
+     *   remove_test_cookie: bool
+     * }
      */
     public function generatePixelData(
         string $cartId,

--- a/Service/PixelService.php
+++ b/Service/PixelService.php
@@ -50,14 +50,16 @@ class PixelService
      * Generate pixel data for A/B test tracking.
      *
      * @param string $cartId Masked or numeric cart identifier.
-     * @param array $testResult A/B test result data; expects optional 'id' key.
+     * @param array $testResult A/B test result data; may contain an optional 'id'
+     *     key, which is used to populate both the 'test_id' and 'variation_id'
+     *     fields in the returned payload.
      * @param string $action Tracking action label (e.g. 'redirect_check').
      * @return array{
      *   cart_id: string,
-     *   test_id: string|null,
+     *   test_id: string|null,        // Derived from $testResult['id'] when present.
      *   action: string,
      *   timestamp: int,
-     *   variation_id: string|null,
+     *   variation_id: string|null,   // Mirrors test_id; also derived from $testResult['id'].
      *   remove_test_cookie: bool
      * }
      */


### PR DESCRIPTION
This pull request mainly improves documentation for several service methods by clarifying their purpose, describing their behavior in detail, and specifying more precise return types. These enhancements will help developers understand how these methods work and what to expect from their outputs.

Documentation improvements for service methods:

* [`Service/CookieService.php`](diffhunk://#diff-cf0c2e2284ff54dabf5bb46bee154bd583353e3c29219469a023e7a492b4f3a4L173-R179): Expanded the docblock for `getTrackingCookies()` to clarify how analytics cookies are collected and which sources take precedence. Also updated the return type to a more specific map.
* [`Service/CookieService.php`](diffhunk://#diff-cf0c2e2284ff54dabf5bb46bee154bd583353e3c29219469a023e7a492b4f3a4L206-R215): Improved the docblock for `getStoreCookies()` to specify the types of store-state cookies collected and how injected cookies override browser cookies. Updated the return type for clarity.
* [`Service/EncryptionService.php`](diffhunk://#diff-c0f116b0ce3b95399f555d5923f4f6f6be0a2e19b4e0f94dbb9dad0d6ac31169L62-R69): Enhanced the docblock for `getTapbuyKey()` to describe the encryption process, error handling, and the format of the returned payload.
* [`Service/EncryptionService.php`](diffhunk://#diff-c0f116b0ce3b95399f555d5923f4f6f6be0a2e19b4e0f94dbb9dad0d6ac31169L83-R96): Clarified the docblock for `buildEncryptionData()` to explain how session and cart data are extracted, and provided a detailed return type.
* [`Service/PixelService.php`](diffhunk://#diff-a34fac32aefb5593150e7b4bc297608a4a01b5012a89830e6de65b2b253273dfL50-R62): Updated the docblock for `generatePixelData()` to specify input parameters, expected keys in the A/B test result, and the structure of the returned array.