### PR TITLE
PDT-480 Remove dead code

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -50,7 +50,7 @@
         </arguments>
     </type>
 
-    <!-- Make TapbuyLogger use the Monolog configuration -->
+    <!-- Configure TapbuyLogger directly with its own channel name, handler, and TraceIdProcessor -->
     <type name="Tapbuy\RedirectTracking\Logger\TapbuyLogger">
         <arguments>
             <argument name="name" xsi:type="string">tapbuy</argument>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -50,19 +50,7 @@
         </arguments>
     </type>
 
-    <virtualType name="Tapbuy\RedirectTracking\Logger\VirtualLogger" type="Magento\Framework\Logger\Monolog">
-        <arguments>
-            <argument name="name" xsi:type="string">tapbuy</argument>
-            <argument name="handlers" xsi:type="array">
-                <item name="tapbuy_handler" xsi:type="object">Tapbuy\RedirectTracking\Logger\Handler</item>
-            </argument>
-            <argument name="processors" xsi:type="array">
-                <item name="trace_id" xsi:type="object">Tapbuy\RedirectTracking\Logger\TraceIdProcessor</item>
-            </argument>
-        </arguments>
-    </virtualType>
-
-    <!-- Make TapbuyLogger use the virtual logger configuration -->
+    <!-- Make TapbuyLogger use the Monolog configuration -->
     <type name="Tapbuy\RedirectTracking\Logger\TapbuyLogger">
         <arguments>
             <argument name="name" xsi:type="string">tapbuy</argument>


### PR DESCRIPTION
This pull request makes a small change to the logging configuration in the `etc/di.xml` file. The virtual type configuration for `Tapbuy\RedirectTracking\Logger\VirtualLogger` has been removed, and the comment for `TapbuyLogger` has been updated to reflect that it now uses the Monolog configuration directly.