### PR TITLE
PDT-466 Decrease curl timeout

### DIFF
--- a/Model/Service.php
+++ b/Model/Service.php
@@ -239,7 +239,7 @@ class Service implements TapbuyServiceInterface
         }
 
         // Set timeout
-        $this->curl->setOption(CURLOPT_TIMEOUT, 30);
-        $this->curl->setOption(CURLOPT_CONNECTTIMEOUT, 10);
+        $this->curl->setOption(CURLOPT_TIMEOUT, 10);
+        $this->curl->setOption(CURLOPT_CONNECTTIMEOUT, 3);
     }
 }

--- a/Model/Service.php
+++ b/Model/Service.php
@@ -26,6 +26,19 @@ use Magento\Sales\Model\Order;
 class Service implements TapbuyServiceInterface
 {
     /**
+     * Maximum time in seconds for the entire cURL request (connect + transfer).
+     * Kept low because this call is synchronous in the checkout flow — a slow
+     * or unreachable Tapbuy API must not stall the shopper's browser.
+     */
+    private const CURL_TIMEOUT = 10;
+
+    /**
+     * Maximum time in seconds to establish the TCP connection.
+     * Must be strictly less than CURL_TIMEOUT.
+     */
+    private const CURL_CONNECT_TIMEOUT = 3;
+
+    /**
      * @param ConfigInterface $config
      * @param Curl $curl
      * @param Json $json
@@ -239,7 +252,7 @@ class Service implements TapbuyServiceInterface
         }
 
         // Set timeout
-        $this->curl->setOption(CURLOPT_TIMEOUT, 10);
-        $this->curl->setOption(CURLOPT_CONNECTTIMEOUT, 3);
+        $this->curl->setOption(CURLOPT_TIMEOUT, self::CURL_TIMEOUT);
+        $this->curl->setOption(CURLOPT_CONNECTTIMEOUT, self::CURL_CONNECT_TIMEOUT);
     }
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the timeout settings for cURL requests in the `Model/Service.php` file. The timeouts have been reduced to improve responsiveness.

* Reduced `CURLOPT_TIMEOUT` from 30 seconds to 10 seconds, and `CURLOPT_CONNECTTIMEOUT` from 10 seconds to 3 seconds in the `configureCurl` method.