### PR TITLE
PDT-480 Fix forceRedirect type

### DIFF
--- a/Api/TapbuyServiceInterface.php
+++ b/Api/TapbuyServiceInterface.php
@@ -37,13 +37,13 @@ interface TapbuyServiceInterface
      * Trigger A/B test
      *
      * @param CartInterface $quote
-     * @param bool|null $forceRedirect
+     * @param string|null $forceRedirect
      * @param string|null $referer
      * @return array
      */
     public function triggerABTest(
         CartInterface $quote,
-        ?bool $forceRedirect = null,
+        ?string $forceRedirect = null,
         ?string $referer = null
     ): array;
 }

--- a/Model/Service.php
+++ b/Model/Service.php
@@ -182,13 +182,13 @@ class Service implements TapbuyServiceInterface
      * Trigger A/B test
      *
      * @param \Magento\Quote\Api\Data\CartInterface $quote
-     * @param bool|null $forceRedirect
+     * @param string|null $forceRedirect
      * @param string|null $referer
      * @return array
      */
     public function triggerABTest(
         CartInterface $quote,
-        ?bool $forceRedirect = null,
+        ?string $forceRedirect = null,
         ?string $referer = null
     ): array {
 


### PR DESCRIPTION
This pull request updates the `triggerABTest` method signature in both the interface and implementation to improve parameter consistency. The most important changes are:

Parameter type update:

* Changed the `forceRedirect` parameter type from `bool|null` to `string|null` in the `triggerABTest` method signature in both `Api/TapbuyServiceInterface.php` and `Model/Service.php` to ensure consistency and allow for string values. [[1]](diffhunk://#diff-aa0994a98cbbb086704b0b30ca9d8bcbea066d3ff51e4acd4cb3ed7c6fb00d37L40-R46) [[2]](diffhunk://#diff-315cfdb5c298e431610d30e3315202a963ca51fe5b5d8345fd03520e1e09c6ddL185-R191)