### PR TITLE
PDT-469 Fix get all cookies

### DIFF
--- a/Service/CookieService.php
+++ b/Service/CookieService.php
@@ -217,7 +217,7 @@ class CookieService
      */
     private function getAllRequestCookies(): array
     {
-        $cookieHeader = $this->request->getCookies();
+        $cookieHeader = $this->request->getHeaders()->get('Cookie');
         return $cookieHeader ? $cookieHeader->getArrayCopy() : [];
     }
 


### PR DESCRIPTION
This pull request makes a small change to how cookies are retrieved in the `CookieService`. The method now gets cookies directly from the `Cookie` header instead of using the `getCookies()` method on the request object.