### PR TITLE
PDT-476 Scrub sensitive data in logs

### DIFF
--- a/Api/ConfigInterface.php
+++ b/Api/ConfigInterface.php
@@ -61,4 +61,13 @@ interface ConfigInterface
      * @return string
      */
     public function getOrderConfirmationMode(?int $storeId = null): string;
+
+    /**
+     * Get the URL of the data-scrubbing keys API endpoint.
+     * Returns an empty string when log anonymization is disabled.
+     *
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getScrubbingKeysUrl(?int $storeId = null): string;
 }

--- a/Api/ConfigInterface.php
+++ b/Api/ConfigInterface.php
@@ -65,9 +65,9 @@ interface ConfigInterface
     /**
      * Get the URL of the data-scrubbing keys API endpoint.
      * Returns an empty string when log anonymization is disabled.
+     * This is a global (default-scope) setting — not configurable per website or store view.
      *
-     * @param int|null $storeId
      * @return string
      */
-    public function getScrubbingKeysUrl(?int $storeId = null): string;
+    public function getScrubbingKeysUrl(): string;
 }

--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -14,11 +14,15 @@ declare(strict_types=1);
 
 namespace Tapbuy\RedirectTracking\Logger;
 
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem\DriverInterface;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\LogRecord;
+use Tapbuy\DataScrubber\Anonymizer;
+use Tapbuy\DataScrubber\Keys;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 use Tapbuy\RedirectTracking\Api\LogHandlerInterface;
 use Tapbuy\RedirectTracking\Api\TapbuyConstants;
 
@@ -40,14 +44,40 @@ class Handler extends StreamHandler implements LogHandlerInterface
     protected $filePath;
 
     /**
+     * @var ConfigInterface
+     */
+    private ConfigInterface $config;
+
+    /**
+     * @var DirectoryList
+     */
+    private DirectoryList $directoryList;
+
+    /**
+     * @var Anonymizer|null Lazily initialized; null when anonymization is disabled or unavailable.
+     */
+    private ?Anonymizer $anonymizer = null;
+
+    /**
+     * @var bool Whether we already attempted (and failed) to build the anonymizer.
+     */
+    private bool $anonymizerInitAttempted = false;
+
+    /**
      * @param DriverInterface $filesystem
+     * @param ConfigInterface $config
+     * @param DirectoryList $directoryList
      * @param string|null $filePath
      */
     public function __construct(
         DriverInterface $filesystem,
+        ConfigInterface $config,
+        DirectoryList $directoryList,
         ?string $filePath = null
     ) {
         $this->filesystem = $filesystem;
+        $this->config = $config;
+        $this->directoryList = $directoryList;
 
         // Determine log file path
         if ($filePath === null) {
@@ -76,6 +106,9 @@ class Handler extends StreamHandler implements LogHandlerInterface
      */
     protected function write(array|LogRecord $record): void
     {
+        // Anonymize the entire record before any further processing.
+        $record = $this->anonymizeRecord($record);
+
         // Normalize record for both Monolog 2.x (array) and 3.x (LogRecord)
         $isLogRecord = $record instanceof LogRecord;
         $context = $isLogRecord ? $record->context : ($record['context'] ?? []);
@@ -139,6 +172,80 @@ class Handler extends StreamHandler implements LogHandlerInterface
         if ($formatted && !empty($this->filePath)) {
             $this->filesystem->filePutContents($this->filePath, $formatted, FILE_APPEND | LOCK_EX);
         }
+    }
+
+    /**
+     * Anonymize the full log record (message, context, extra) using the configured scrubbing keys.
+     * Returns the record unchanged when anonymization is disabled or unavailable (fail open).
+     *
+     * Compatible with both Monolog 2.x (array) and Monolog 3.x (LogRecord).
+     *
+     * @param array|LogRecord $record
+     * @return array|LogRecord
+     */
+    private function anonymizeRecord(array|LogRecord $record): array|LogRecord
+    {
+        $anonymizer = $this->getAnonymizer();
+        if ($anonymizer === null) {
+            return $record;
+        }
+
+        $isLogRecord = $record instanceof LogRecord;
+
+        $toAnonymize = [
+            'message' => $isLogRecord ? $record->message : ($record['message'] ?? ''),
+            'context' => $isLogRecord ? $record->context : ($record['context'] ?? []),
+            'extra'   => $isLogRecord ? $record->extra   : ($record['extra']   ?? []),
+        ];
+
+        /** @var array $anonymized */
+        $anonymized = $anonymizer->anonymizeObject($toAnonymize);
+
+        if ($isLogRecord) {
+            return $record->with(
+                message: $anonymized['message'],
+                context: $anonymized['context'],
+                extra: $anonymized['extra'],
+            );
+        }
+
+        $record['message'] = $anonymized['message'];
+        $record['context'] = $anonymized['context'];
+        $record['extra']   = $anonymized['extra'];
+
+        return $record;
+    }
+
+    /**
+     * Return the lazily-initialized Anonymizer, or null if anonymization is disabled or initialization fails.
+     *
+     * Fail-open: any exception during setup is swallowed so that logging is never blocked.
+     */
+    private function getAnonymizer(): ?Anonymizer
+    {
+        if ($this->anonymizer !== null) {
+            return $this->anonymizer;
+        }
+
+        if ($this->anonymizerInitAttempted) {
+            return null;
+        }
+
+        $this->anonymizerInitAttempted = true;
+
+        $url = $this->config->getScrubbingKeysUrl();
+        if ($url === '') {
+            return null;
+        }
+
+        try {
+            $cachePath = $this->directoryList->getPath(DirectoryList::VAR_DIR) . '/tapbuy-scrubbing-keys.json';
+            $this->anonymizer = new Anonymizer(new Keys($url, $cachePath));
+        } catch (\Throwable $e) {
+            error_log('[Tapbuy] Failed to initialize log anonymizer: ' . $e->getMessage());
+        }
+
+        return $this->anonymizer;
     }
 
     /**

--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -106,9 +106,6 @@ class Handler extends StreamHandler implements LogHandlerInterface
      */
     protected function write(array|LogRecord $record): void
     {
-        // Anonymize the entire record before any further processing.
-        $record = $this->anonymizeRecord($record);
-
         // Normalize record for both Monolog 2.x (array) and 3.x (LogRecord)
         $isLogRecord = $record instanceof LogRecord;
         $context = $isLogRecord ? $record->context : ($record['context'] ?? []);
@@ -152,6 +149,9 @@ class Handler extends StreamHandler implements LogHandlerInterface
                 $record['context']['stacktrace'] = $context['exception']['stacktrace'];
             }
         }
+
+        // Anonymize after all context enrichment so the final written payload is fully scrubbed.
+        $record = $this->anonymizeRecord($record);
 
         // Format the record using the formatter (JsonFormatter)
         $formatted = '';

--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -28,10 +28,9 @@ use Tapbuy\RedirectTracking\Api\TapbuyConstants;
 
 class Handler extends StreamHandler implements LogHandlerInterface
 {
-    /**
-     * @var string
-     */
     protected const LOG_FILE = TapbuyConstants::LOG_FILE_NAME;
+
+    protected const SCRUBBING_KEYS_CACHE_FILE = 'tapbuy-scrubbing-keys.json';
 
     /**
      * @var DriverInterface
@@ -239,7 +238,7 @@ class Handler extends StreamHandler implements LogHandlerInterface
         }
 
         try {
-            $cachePath = $this->directoryList->getPath(DirectoryList::VAR_DIR) . '/tapbuy-scrubbing-keys.json';
+            $cachePath = $this->directoryList->getPath(DirectoryList::VAR_DIR) . '/' . self::SCRUBBING_KEYS_CACHE_FILE;
             $this->anonymizer = new Anonymizer(new Keys($url, $cachePath));
         } catch (\Throwable $e) {
             error_log('[Tapbuy] Failed to initialize log anonymizer: ' . $e->getMessage());

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -23,6 +23,7 @@ class Config implements ConfigInterface
     public const XML_PATH_ENCRYPTION_KEY = 'tapbuy/api/encryption_key';
     public const XML_PATH_LOCALE_FORMAT = 'tapbuy/api/locale_format';
     public const XML_PATH_ORDER_CONFIRMATION_MODE = 'tapbuy/tracking/order_confirmation_mode';
+    public const XML_PATH_SCRUBBING_KEYS_URL = 'tapbuy/logging/scrubbing_keys_url';
 
     /**
      * @param ScopeConfigInterface $scopeConfig
@@ -109,5 +110,21 @@ class Config implements ConfigInterface
             ScopeInterface::SCOPE_STORE,
             $storeId
         ) ?: ConfigInterface::ORDER_CONFIRMATION_MODE_GRAPHQL;
+    }
+
+    /**
+     * Get the URL of the data-scrubbing keys API endpoint.
+     * Returns an empty string when log anonymization is disabled.
+     *
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getScrubbingKeysUrl(?int $storeId = null): string
+    {
+        return (string) $this->scopeConfig->getValue(
+            self::XML_PATH_SCRUBBING_KEYS_URL,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -115,16 +115,15 @@ class Config implements ConfigInterface
     /**
      * Get the URL of the data-scrubbing keys API endpoint.
      * Returns an empty string when log anonymization is disabled.
+     * This is a global (default-scope) setting — not configurable per website or store view.
      *
-     * @param int|null $storeId
      * @return string
      */
-    public function getScrubbingKeysUrl(?int $storeId = null): string
+    public function getScrubbingKeysUrl(): string
     {
         return (string) $this->scopeConfig->getValue(
             self::XML_PATH_SCRUBBING_KEYS_URL,
-            ScopeInterface::SCOPE_STORE,
-            $storeId
+            ScopeConfigInterface::SCOPE_TYPE_DEFAULT
         );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "magento/module-integration": "^100.4",
         "magento/module-quote": "^101.2",
         "magento/module-graph-ql": "^100.4",
-        "phpseclib/phpseclib": "^3.0"
+        "phpseclib/phpseclib": "^3.0",
+        "tapbuy/data-scrubber": "^1.0"
     },
     "autoload": {
         "files": [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -52,7 +52,7 @@
             </group>
             <group id="logging" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Logging Settings</label>
-                <field id="scrubbing_keys_url" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="scrubbing_keys_url" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Scrubbing Keys URL</label>
                     <comment>URL of the data-scrubbing keys API endpoint used to anonymize log entries. Leave empty to disable log anonymization.</comment>
                     <depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -50,7 +50,16 @@
                     </depends>
                 </field>
             </group>
-
+            <group id="logging" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Logging Settings</label>
+                <field id="scrubbing_keys_url" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Scrubbing Keys URL</label>
+                    <comment>URL of the data-scrubbing keys API endpoint used to anonymize log entries. Leave empty to disable log anonymization.</comment>
+                    <depends>
+                        <field id="tapbuy/general/enabled">1</field>
+                    </depends>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,7 +12,9 @@
             <tracking>
                 <order_confirmation_mode>graphql</order_confirmation_mode>
             </tracking>
-
+            <logging>
+                <scrubbing_keys_url></scrubbing_keys_url>
+            </logging>
         </tapbuy>
     </default>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -41,6 +41,8 @@
     <type name="Tapbuy\RedirectTracking\Logger\Handler">
         <arguments>
             <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+            <argument name="config" xsi:type="object">Tapbuy\RedirectTracking\Api\ConfigInterface</argument>
+            <argument name="directoryList" xsi:type="object">Magento\Framework\App\Filesystem\DirectoryList</argument>
         </arguments>
     </type>
 

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ This module integrates Tapbuy's checkout experience with Magento 2, enabling A/B
 - Seamless integration with Magento's checkout flow
 - Cookie-based session management for A/B test tracking
 - Headless integration
+- Centralized structured logging (JSON) with automatic PII anonymization via [tapbuy/data-scrubber](https://github.com/tapbuy/data-scrubber)
 
 ## Installation
 
@@ -215,6 +216,25 @@ This module supports headless frontends (Next.js, Vue, SPA, etc.) via a pixel-ba
 This module provides the **centralized logging system** for all Tapbuy Magento modules. Logs are written to `var/log/tapbuy-checkout.log` in JSON format and can be retrieved via GraphQL for forwarding to Sentry.
 
 For complete documentation on the logging system, including usage examples, best practices, and API integration, see **[docs/LOGGING.md](./docs/LOGGING.md)**.
+
+### Anonymized Logging
+
+Log entries are automatically **anonymized before being written to disk**, using the [tapbuy/data-scrubber](https://github.com/tapbuy/data-scrubber) library. This ensures that sensitive personal data (names, emails, addresses, payment details, etc.) is redacted from log files, even when full context objects are logged.
+
+**How it works:**
+
+- The `Handler` fetches a list of scrubbing keys from a configurable URL (set via **Stores > Configuration > Tapbuy > Checkout Settings > Scrubbing Keys URL**).
+- Keys are cached locally to `var/tapbuy-scrubbing-keys.json` to avoid repeated remote fetches.
+- On every log write, the full record (message, context, extra) is passed through `Anonymizer::anonymizeObject()` before formatting and writing.
+- Anonymization is **fail-open**: if the scrubbing keys URL is not configured, or if initialization fails for any reason, the record is written as-is so that logging is never blocked.
+
+**Configuration:**
+
+| Setting | Description |
+|---|---|
+| **Scrubbing Keys URL** | Remote URL that returns the JSON list of fields to redact. Leave empty to disable anonymization. |
+
+> The scrubbing keys are managed centrally by the Tapbuy API and define which field names (e.g. `email`, `firstname`, `card_number`) should be replaced with anonymized tokens in log output.
 
 ## Development Mode
 


### PR DESCRIPTION
This pull request introduces automatic PII anonymization for log entries using the `tapbuy/data-scrubber` library. The logging handler now scrubs sensitive data from log records before writing, based on configurable scrubbing keys fetched from a remote URL. This feature is configurable via the admin panel and ensures that logs do not contain personal information, improving compliance and security.

**Logging Anonymization Integration:**

* The `Logger/Handler.php` class now uses the `tapbuy/data-scrubber` library to anonymize log entries. The handler fetches scrubbing keys from a configurable URL, caches them locally, and scrubs all log record fields (message, context, extra) before writing. If anonymization is disabled or initialization fails, logs are written as-is to avoid blocking. [[1]](diffhunk://#diff-06e43a7db64b11d914491b58e9fd57d5970c94e29006625ae4b1c9f609ed757eR17-R34) [[2]](diffhunk://#diff-06e43a7db64b11d914491b58e9fd57d5970c94e29006625ae4b1c9f609ed757eR45-R79) [[3]](diffhunk://#diff-06e43a7db64b11d914491b58e9fd57d5970c94e29006625ae4b1c9f609ed757eR152-R154) [[4]](diffhunk://#diff-06e43a7db64b11d914491b58e9fd57d5970c94e29006625ae4b1c9f609ed757eR176-R249)
* The `composer.json` file adds `tapbuy/data-scrubber` as a dependency.

**Configuration Enhancements:**

* The `Api/ConfigInterface.php` and `Model/Config.php` files add a method and constant for retrieving the scrubbing keys URL, which is used to control anonymization. [[1]](diffhunk://#diff-fa75620d5202845548da4ea2a707f909d0eac81be8122ee64afc704d37142ae3R64-R72) [[2]](diffhunk://#diff-9d8f8bb39dfd46426a24d8fd10c888e246a3a501d2684a7a3af5da46b8c8af58R26) [[3]](diffhunk://#diff-9d8f8bb39dfd46426a24d8fd10c888e246a3a501d2684a7a3af5da46b8c8af58R114-R128)
* The admin configuration (`etc/adminhtml/system.xml`) introduces a new "Logging Settings" group with a field for the scrubbing keys URL, and `etc/config.xml` sets the default value. [[1]](diffhunk://#diff-89223417b0d8b4f3be81bd4caf5573ad94c01df7d6e897cb48352e7c6204af25L53-R62) [[2]](diffhunk://#diff-3bf05ed19b66e6338063bab879891ccbe11ba078352dec2a9ec57ec37bff15bbL15-R17)
* Dependency injection is updated to provide the necessary configuration and directory objects to the logging handler (`etc/di.xml`).

**Documentation Updates:**

* The `readme.md` file is updated to document the new anonymized logging feature, including how it works and how to configure it. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R13) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R220-R238)